### PR TITLE
disable make without explicit 1st-arg type, like make(2, 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,10 +141,11 @@ julia> rand(Normal(), SparseMatrixCSC, 0.3, 2, 3) # equivalent to sprandn(2, 3, 
   [2, 1]  =  0.448981
   [1, 2]  =  0.730103
 
-# like for Array, sparse arrays enjoy to be special cased: `SparseVector` or `SparseMatrixCSC` can be omitted:
+# like for Array, sparse arrays enjoy to be special cased: `SparseVector` or `SparseMatrixCSC`
+# can be omitted in the `rand` call (not in the `make` call):
 
-julia> rand(make(make(1:9, 0.3, 2, 3), 0.1, 4)) # possible, bug ugly output when non-empty :-/
-4-element SparseVector{SparseMatrixCSC{Int64,Int64},Int64} with 0 stored entries
+julia> rand(make(SparseVector, 1:9, 0.3, 2), 0.1, 4, 3) # possible, bug ugly output when non-empty :-/
+4×3 SparseMatrixCSC{SparseVector{Int64,Int64},Int64} with 0 stored entries
 
 julia> rand(String, 4) # equivalent to randstring(4)
 "5o75"

--- a/src/containers.jl
+++ b/src/containers.jl
@@ -118,7 +118,10 @@ _make_cont(args...) = make(args...)
 @make_array_container(t::Type{<:Array})
 @make_array_container(t::Type{<:BitArray})
 @make_array_container(t::AbstractFloat)
-_make_cont(t::AbstractFloat, x, dims::Dims) = make(x, t, dims)
+_make_cont(t::AbstractFloat, x, dims::Dims{1}) = make(SparseVector,    x, t, dims)
+_make_cont(t::AbstractFloat,    dims::Dims{1}) = make(SparseVector,       t, dims)
+_make_cont(t::AbstractFloat, x, dims::Dims{2}) = make(SparseMatrixCSC, x, t, dims)
+_make_cont(t::AbstractFloat,    dims::Dims{2}) = make(SparseMatrixCSC,    t, dims)
 
 ## sets/dicts
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -456,17 +456,6 @@ maketype(A::Type{Array{T,N}},         _, ::Dims{N}) where {T, N} = Array{T, N}
 maketype(A::Type{Array{T,N} where T}, X, ::Dims{N}) where {N}    = Array{val_gentype(X), N}
 maketype(A::Type{Array},              X, ::Dims{N}) where {N}    = Array{val_gentype(X), N}
 
-# special shortcut
-
-make(X,         dims::Dims)                              = make(Array, X,                       dims)
-make(X,         d1::Integer, dims::Integer...)           = make(Array, X,                       Dims((d1, dims...)))
-make(::Type{X}, dims::Dims)           where {X}          = make(Array, X,                       dims)
-make(::Type{X}, d1::Integer, dims::Integer...) where {X} = make(Array, X,                       Dims((d1, dims...)))
-make(           dims::Integer...)                        = make(Array, default_sampling(Array), Dims(dims))
-
-# omitted: make(dims::Dims)
-# for the same reason that rand(dims::Dims) doesn't produce an array, i.e. it produces a scalar picked from the tuple
-
 #### BitArray
 
 default_sampling(::Type{<:BitArray}) = Uniform(Bool)
@@ -495,21 +484,6 @@ make(T::Type{SparseMatrixCSC}, p::AbstractFloat, d1::Integer, d2::Integer) = mak
 make(T::Type{SparseVector},    p::AbstractFloat, dims::Dims{1}) = make(T, default_sampling(T), p, dims)
 make(T::Type{SparseMatrixCSC}, p::AbstractFloat, dims::Dims{2}) = make(T, default_sampling(T), p, dims)
 
-make(X,         p::AbstractFloat, dims::Dims{1})           = make(SparseVector, X, p, dims)
-make(::Type{X}, p::AbstractFloat, dims::Dims{1}) where {X} = make(SparseVector, X, p, dims)
-make(X,         p::AbstractFloat, dims::Dims{2})           = make(SparseMatrixCSC, X, p, dims)
-make(::Type{X}, p::AbstractFloat, dims::Dims{2}) where {X} = make(SparseMatrixCSC, X, p, dims)
-
-make(X,         p::AbstractFloat, d1::Integer)                        = make(X,                               p, Dims(d1))
-make(X,         p::AbstractFloat, d1::Integer, d2::Integer)           = make(X,                               p, Dims((d1, d2)))
-make(::Type{X}, p::AbstractFloat, d1::Integer) where {X}              = make(X,                               p, Dims(d1))
-make(::Type{X}, p::AbstractFloat, d1::Integer, d2::Integer) where {X} = make(X,                               p, Dims((d1, d2)))
-make(           p::AbstractFloat, dims::Dims)                         = make(default_sampling(AbstractArray), p, dims)
-make(           p::AbstractFloat, d1::Integer)                        = make(default_sampling(AbstractArray), p, Dims(d1))
-make(           p::AbstractFloat, d1::Integer, d2::Integer)           = make(default_sampling(AbstractArray), p, Dims((d1, d2)))
-
-# disambiguate (away from make(String, chars, n::Integer))
-make(::Type{String}, p::AbstractFloat, d1::Integer) = make(String, p, Dims(d1))
 
 Sampler(RNG::Type{<:AbstractRNG}, c::Make3{A}, n::Repetition) where {A<:AbstractSparseArray} =
     SamplerTag{Cont{A}}((sp = sampler(RNG, c.x, n),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -498,20 +498,21 @@ end
 
     @test rand(make(Array, spString, 9)) isa Array{String}
     @test rand(make(BitArray, Sampler(MersenneTwister, [0, 0, 0, 1]), 9)) isa BitArray
-
+    # TODO: below was testing without explicit `Array` as 1st argument, so this test
+    # may now be obsolete, redundant with tests above
     for dims = ((), (2, 3), (0x2, 3), (2,), (0x2,)),
         s    = ([], [Int], [1:3])
 
         T = s == [] ? Float64 : Int
         if dims != ()
-            a = rand(make(s..., dims...))
+            a = rand(make(Array, s..., dims...))
             @test a isa Array{T,length(dims)}
             if s == [1:3]
                 @test all(in(1:3), a)
             end
         end
-        if s != [] && dims isa Dims
-            a = rand(make(s..., dims))
+        if dims isa Dims
+            a = rand(make(Array, s..., dims))
             @test a isa Array{T,length(dims)}
             if s == [1:3]
                 @test all(in(1:3), a)
@@ -526,17 +527,17 @@ end
                     [(2,3)]             => 2,
                     [6]                 => 1,
                     [2, 3]              => 2,
-                    [Int8(2), Int16(3)] => 2),
-        form = ([], [dim == 1 ? SparseVector : SparseMatrixCSC])
+                    [Int8(2), Int16(3)] => 2)
 
-        s = rand(make(form..., k..., 0.3, d...))
+        typ = dim == 1 ? SparseVector : SparseMatrixCSC
+
+        s = rand(make(typ, k..., 0.3, d...))
         @test s isa (dim == 1 ? SparseVector{Float64,Int} :
                                 SparseMatrixCSC{Float64,Int})
         @test length(s) == 6
     end
-    @test rand(make(spString, 0.3, 9)) isa SparseVector{String}
-    @test rand(make(String, 0.9, 2)) isa SparseVector{String} # can be ambiguous with make(String, chars, n)
-    @test rand(make(make(1:9, 0.3, 2, 3), .1, 4)) isa SparseVector{SparseMatrixCSC{Int64,Int64},Int64}
+    @test rand(make(SparseVector, spString, 0.3, 9)) isa SparseVector{String}
+    @test rand(make(SparseVector, make(SparseMatrixCSC, 1:9, 0.3, 2, 3), .1, 4)) isa SparseVector{SparseMatrixCSC{Int64,Int64},Int64}
 end
 
 @testset "rand(make(default))" begin


### PR DESCRIPTION
Having the shortcut `make(2, 3)` for `make(Array, 2, 3)`, which mirrors
`rand(2, 3)`, is convenient, but the form `make(Int, 2, 3)` leads to
ambiguities for types which take 2 integer args, e.g.
`make(MyType, 2, 3)`. Let's favor simplicity for custom-defined types.

Moreover,  the terminology "make" makes sense when the first arg
refers to the type to be "made", e.g. in `make(Int, 2, 3)` we didn't
make an `Int`, but an array, so the meaning of "make" was lost.