### PR TITLE
array generation: allow specifying dims as distributions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ julia> julia> rand(Bernoulli(0.2), BitVector, 10) # using the Bernoulli distribu
  false
   true
 
+julia> rand(Int8, Array, 3, 5) # more explicit syntax than rand(Int8, 3, 5) ...
+3×5 Array{Int8,2}:
+  -4  -110  70   -4    63
+ -38     4  55  -86  -106
+ -56  -124  46  118   114
+
+julia> rand(Int8, Array, 1:3, 3:5) # ... but dimensions can be specified with a distribution!
+                                   #     the size will be computed as (rand(1:3), rand(3:5))
+2×5 Array{Int8,2}:
+   -2  -43  106   -74   18
+ -117  -97    2  -126  125
+
 julia> rand(1:3, NTuple{3}) # NTuple{3} considered as a container, equivalent to rand(make(NTuple{3}, 1:3))
 (3, 3, 1)
 

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -57,6 +57,18 @@ _deduce_type(::Type{T}, ::Val{true},  ::Type{X}) where {T,X} = T
 _deduce_type(::Type{T}, ::Val{false}, ::Type{X}) where {T,X} = T{X}
 
 
+## Const
+
+# distribution always yielding the same value
+struct Const{T} <: Distribution{T}
+    x::T
+end
+
+Base.getindex(c::Const) = c.x
+
+rand(::AbstractRNG, c::SamplerTrivial{<:Const}) = c[][]
+
+
 ## Uniform
 
 abstract type Uniform{T} <: Distribution{T} end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -79,7 +79,20 @@ const spString = Sampler(MersenneTwister, String)
             a = rand(rng..., Int8, A, 10)
             @test a isa Vector{AT}
             @test all(in(rInt8), a)
+            a = rand(rng..., Int8, A, 10:20)
+            @test a isa Vector{AT}
+            @test all(in(rInt8), a)
+            @test length(a) ∈ 10:20
         end
+        a = rand(rng..., Int8, Array, make(Tuple, 1:3, 1:4))
+        @test a isa Matrix{Int8}
+        @test all(issubset.(size(a), (1:3, 1:4)))
+        a = rand(rng..., Int8, Array, 3, 1:4)
+        @test a isa Matrix{Int8}
+        @test all(issubset.(size(a), (3:3, 1:4)))
+        a = rand(rng..., Array, 1:3, 4)
+        @test a isa Matrix{Float64}
+        @test all(issubset.(size(a), (1:3, 4:4)))
     end
 
     # Set


### PR DESCRIPTION
The number of dimensions is still fixed, but the sizes can be
computed at runtime, when specified as a distributions.
For example `rand(make(Vector, Int, 1:3))` creates a `Vector{Int}`
of random length in `1:3`.
