### PR TITLE
allow non-type as first argument of make(x...)

### DIFF
--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -39,6 +39,10 @@ maketype(::Type{T}, x...) where {T} = T
 
 make(::Type{T}, x...) where {T} = Make{maketype(T, x...)}(x...)
 
+# make(x) is defined in sampling.jl, and is a special case wrapping already valid
+# distributions (explicit or implicit)
+make(x1, x2, xs...) = Make{maketype(x1, x2, xs...)}(x1, x2, xs...)
+
 find_deduced_type(::Type{T}, ::X,     ) where {T,X} = deduce_type(T, gentype(X))
 find_deduced_type(::Type{T}, ::Type{X}) where {T,X} = deduce_type(T, X)
 

--- a/src/sampling.jl
+++ b/src/sampling.jl
@@ -15,12 +15,21 @@ sampler(rng::AbstractRNG, X, n::Repetition=Val(Inf)) = sampler(typeof(rng), X, n
 
 make() = make(Float64)
 
-### type
+### type: handles e.g. rand(make(Int))
+
+# rand(rng, ::SamplerType{Make0{X}}) should not be overloaded, as make(T)
+# has this special pass-thru Sampler defined below
 
 Sampler(RNG::Type{<:AbstractRNG}, ::Make0{X}, n::Repetition) where {X} =
     Sampler(RNG, X, n)
 
-### object
+### object: handles e.g. rand(make(1:3))
+
+# make(x) where x isn't a type should create a distribution d such that rand(x) is
+# equivalent to rand(d); so we need to overload make(x) to give a different type
+# than Make1{gentype(x)}, as we can't simply define a generic pass-thru Sampler for
+# that Make1 type (because users expect the default to be a SamplerTrivial{<:Make1{...}},
+# and might want to define only a rand method on this SamplerTrivial)
 
 # like Make1
 struct MakeWrap{T,X} <: Distribution{T}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -579,6 +579,28 @@ end
     @test nt isa NTuple{4,Complex{Int64}}
 end
 
+##  make(x1, xs...)
+
+struct MyType
+    x
+end
+
+RandomExtensions.maketype(x::MyType, y) = eltype(x.x:y)
+
+Base.rand(rng::AbstractRNG,
+          x::Random.SamplerTrivial{<:RandomExtensions.Make2{<:Integer, MyType}}) =
+              rand(rng, x[][1].x:x[][2])
+
+@testset "rand(make(CustomType(), ...))" begin
+    m = MyType(3)
+    @test rand(make(m, 3)) == 3
+    @test rand(make(m, big(5))) isa BigInt
+    @test rand(make(m, big(5))) ∈ 3:5
+    a = rand(make(m, big(6)), 5)
+    @test a isa Vector{BigInt}
+    @test length(a) == 5
+    @test all(∈(3:6), a)
+end
 
 ## @rand
 


### PR DESCRIPTION
Till now, `make(x)` was defined to create an explicit distribution wrapping
a possibly implicit one (`x`). Beside this case, the first argument of
`make(x0, xs...)` had to be a type (typically a supertype of the `gentype` of
the resulting "make value".

But there is no reason to prevent allowing a non-type object as the first
argument; in this case though, this non-type object `x0` has to be passed as
an argument to `Make` (i.e. the resulting `Make` object contains `x0` as
its first element), because keeping only its type would be lossy.